### PR TITLE
Remove unsafe dependency on electron/remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     }
   },
   "dependencies": {
-    "@electron/remote": "^2.0.4",
     "concurrently": "^7.0.0",
     "electron-reload": "^2.0.0-alpha.1",
     "electron-squirrel-startup": "^1.0.0",

--- a/public/controls.js
+++ b/public/controls.js
@@ -1,14 +1,13 @@
-const win = require('@electron/remote').getCurrentWindow();
-console.log(win);
+const { ipcRenderer } = require('electron');
 const closeButton = document.querySelector('.button.close');
 const minimizeButton = document.querySelector('.button.minimize');
 const maximizeButton = document.querySelector('.button.maximize');
 
 let isMaximized = false;
 
-closeButton.addEventListener('click', () => win.close());
-minimizeButton.addEventListener('click', () => win.minimize());
+closeButton.addEventListener('click', () => ipcRenderer.invoke('windowControl', 'close'));
+minimizeButton.addEventListener('click', () => ipcRenderer.invoke('windowControl', 'minimize'));
 maximizeButton.addEventListener('click', () => {
     isMaximized = !isMaximized;
-    isMaximized ? win.unmaximize() : win.maximize();
+    ipcRenderer.invoke('windowControl', isMaximized ? 'unmaximize' : 'maximize');
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
-const remoteMain = require('@electron/remote/main');
-const { app, BrowserWindow, screen } = require('electron');
+const { app, BrowserWindow, screen, ipcMain } = require('electron');
 const path = require('path');
-remoteMain.initialize();
 
 try {
   require('electron-reloader')(module);
@@ -22,11 +20,20 @@ const createWindow = () => {
     frame: false,
     webPreferences: {
       nodeIntegration: true,
-      enableRemoteModule: true,
       contextIsolation: false
     }
   });
-  remoteMain.enable(mainWindow.webContents);
+  ipcMain.handle('windowControl', (_event, data) => {
+    if (data === 'close') {
+      mainWindow.close()
+    } else if (data === 'minimize') {
+      mainWindow.minimize();
+    } else if (data === 'maximize') {
+      mainWindow.maximize();
+    } else if (data === 'unmaximize') {
+      mainWindow.unmaximize();
+    }
+  });
   // and load the index.html of the app.
   mainWindow.loadFile(path.join(__dirname, '../public/index.html'));
 


### PR DESCRIPTION
Use ipcMain and ipcRenderer instead of remote to communicate between main and renderer process.